### PR TITLE
Fix custom rules HANDHLPIOS-363

### DIFF
--- a/SwiftLint/.swiftlint.yml
+++ b/SwiftLint/.swiftlint.yml
@@ -14,6 +14,7 @@ excluded: # paths to ignore during linting. overridden by `included`.
   - Carthage
   - Pods
   - External
+  - Submodules
 
 # rule parameters
 cyclomatic_complexity:


### PR DESCRIPTION
## 1) Remove Excluded folder

I removed the `Submodules` folder because the DKExtensionsSwift was not linted anymore and this would cause the same problem on projects with included frameworks like on Catalyst, Adviqo etc. 
## 2) New rule: empty_commented_line

Now the following empty useless commented out line are found by swiftlint:

```
    // <- should be removed
    // Super Doc
    code_or_function
```
## 3) New rule: missing_brackets_unwrap

Finally a rule to spot the missing brackets around the `??` operator !!

```
return self.value ?? 0 <- warning!
```
## 4) Improvement: missing_brackets

Missing rounded brackets are now found if there are `tabs` and/or `whitespace` before the `if`.
More over, it is now also working for `else if` !

```
if value == 0 { <- warning!
    code
} else if something == nil { <- warning!
    code
}
```
