### PR TITLE
Swiftlint: Add exlcuded path

### DIFF
--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -22,6 +22,7 @@ excluded: # paths to ignore during linting. overridden by `included`.
   - Submodules
   - Generated
   - Core/Model/CoreData
+  - Database/Model
   - fastlane
 
 # rule parameters


### PR DESCRIPTION
I create this PR in order to propose a small improvement/suggestion regarding the Swiftlint file and more important the repo structure.

I believe that it would be nice to have the database related files in `Database/` and not in `Code/Model/Coredata`. That way the models would be in `Database/Model`, the helpers in `Database/Model+Helper` and the `.xcdatamodeld` file in `Database/`.

All DB related files will be in the same separate folder called `Database`. 

The excluded path for swiftlint in `Database/Model`