### PR TITLE
[LifetimeTracker] Add LifetimeTracker helper classes

### DIFF
--- a/LifetimeTracker/LifetimeTrackerSDK.swift
+++ b/LifetimeTracker/LifetimeTrackerSDK.swift
@@ -1,0 +1,40 @@
+//
+//  LifetimeTrackerSDK.swift
+//  SMF-iOS-CommonProjectSetupFiles
+//
+//  Created by Hans Seiffert on 04.12.18.
+//  Copyright © 2018 Smart Mobile Factory GmbH. All rights reserved.
+//
+
+import Foundation
+
+#if canImport(LifetimeTracker)
+import LifetimeTracker
+#endif
+
+struct LifetimeTrackerSDK {
+
+	public enum Visibility {
+		case alwaysHidden
+		case alwaysVisible
+		case visibleWithIssuesDetected
+
+#if canImport(LifetimeTracker)
+
+		var libraryRepresentation: LifetimeTrackerDashboardIntegration.Visibility {
+			switch self {
+			case .alwaysHidden:					return LifetimeTrackerDashboardIntegration.Visibility.alwaysHidden
+			case .alwaysVisible:				return LifetimeTrackerDashboardIntegration.Visibility.alwaysVisible
+			case .visibleWithIssuesDetected:	return LifetimeTrackerDashboardIntegration.Visibility.visibleWithIssuesDetected
+			}
+		}
+
+#endif
+	}
+
+	static func setup(with visibility: LifetimeTrackerSDK.Visibility = .visibleWithIssuesDetected) {
+#if canImport(LifetimeTracker)
+		LifetimeTracker.setup(onUpdate: LifetimeTrackerDashboardIntegration(visibility: visibility.libraryRepresentation, style: .circular).refreshUI)
+#endif
+	}
+}

--- a/LifetimeTracker/SMFBaseCollectionViewController.swift
+++ b/LifetimeTracker/SMFBaseCollectionViewController.swift
@@ -1,0 +1,65 @@
+//
+//  SMFBaseCollectionViewController.swift
+//  SMF-iOS-CommonProjectSetupFiles
+//
+//  Created by Hans Seiffert on 04.12.18.
+//  Copyright © 2018 Smart Mobile Factory GmbH. All rights reserved.
+//
+
+import UIKit
+
+#if canImport(LifetimeTracker)
+
+import LifetimeTracker
+
+#endif
+
+class SMFBaseCollectionViewController: UICollectionViewController, SMFLifetimeTrackable {
+
+	// MARK: - LifetimeTracker Configuration (without import)
+
+	class var lt_maxCount: Int {
+		return 1
+	}
+
+	class var lt_groupName: String? {
+		return String(describing: self)
+	}
+
+	class var lt_groupMaxCount: Int? {
+		return nil
+	}
+
+	// MARK: - LifetimeTracker Configuration (with import)
+
+#if canImport(LifetimeTracker)
+
+	class var lifetimeConfiguration: LifetimeConfiguration {
+		let lifetimeConfiguration = LifetimeConfiguration(maxCount: self.lt_maxCount)
+		lifetimeConfiguration.groupName = self.lt_groupName
+		lifetimeConfiguration.groupMaxCount = self.lt_groupMaxCount
+		return lifetimeConfiguration
+	}
+
+	// MARK: - Initialization
+
+	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+		self.trackLifetime()
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+
+		self.trackLifetime()
+	}
+
+#endif
+}
+
+#if canImport(LifetimeTracker)
+
+extension SMFBaseCollectionViewController: LifetimeTrackable {}
+
+#endif

--- a/LifetimeTracker/SMFBaseSplitViewController.swift
+++ b/LifetimeTracker/SMFBaseSplitViewController.swift
@@ -1,0 +1,65 @@
+//
+//  SMFBaseSplitViewController.swift
+//  SMF-iOS-CommonProjectSetupFiles
+//
+//  Created by Hans Seiffert on 04.12.18.
+//  Copyright © 2018 Smart Mobile Factory GmbH. All rights reserved.
+//
+
+import UIKit
+
+#if canImport(LifetimeTracker)
+
+import LifetimeTracker
+
+#endif
+
+class SMFBaseSplitViewController: UISplitViewController, SMFLifetimeTrackable {
+
+	// MARK: - LifetimeTracker Configuration (without import)
+
+	class var lt_maxCount: Int {
+		return 1
+	}
+
+	class var lt_groupName: String? {
+		return String(describing: self)
+	}
+
+	class var lt_groupMaxCount: Int? {
+		return nil
+	}
+
+	// MARK: - LifetimeTracker Configuration (with import)
+
+#if canImport(LifetimeTracker)
+
+	class var lifetimeConfiguration: LifetimeConfiguration {
+		let lifetimeConfiguration = LifetimeConfiguration(maxCount: self.lt_maxCount)
+		lifetimeConfiguration.groupName = self.lt_groupName
+		lifetimeConfiguration.groupMaxCount = self.lt_groupMaxCount
+		return lifetimeConfiguration
+	}
+
+	// MARK: - Initialization
+
+	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+		self.trackLifetime()
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+
+		self.trackLifetime()
+	}
+
+#endif
+}
+
+#if canImport(LifetimeTracker)
+
+extension SMFBaseSplitViewController: LifetimeTrackable {}
+
+#endif

--- a/LifetimeTracker/SMFBaseTableViewController.swift
+++ b/LifetimeTracker/SMFBaseTableViewController.swift
@@ -1,0 +1,65 @@
+//
+//  SMFBaseTableViewController.swift
+//  SMF-iOS-CommonProjectSetupFiles
+//
+//  Created by Hans Seiffert on 04.12.18.
+//  Copyright © 2018 Smart Mobile Factory GmbH. All rights reserved.
+//
+
+import UIKit
+
+#if canImport(LifetimeTracker)
+
+import LifetimeTracker
+
+#endif
+
+class SMFBaseTableViewController: UITableViewController, SMFLifetimeTrackable {
+
+	// MARK: - LifetimeTracker Configuration (without import)
+
+	class var lt_maxCount: Int {
+		return 1
+	}
+
+	class var lt_groupName: String? {
+		return String(describing: self)
+	}
+
+	class var lt_groupMaxCount: Int? {
+		return nil
+	}
+
+	// MARK: - LifetimeTracker Configuration (with import)
+
+#if canImport(LifetimeTracker)
+
+	class var lifetimeConfiguration: LifetimeConfiguration {
+		let lifetimeConfiguration = LifetimeConfiguration(maxCount: self.lt_maxCount)
+		lifetimeConfiguration.groupName = self.lt_groupName
+		lifetimeConfiguration.groupMaxCount = self.lt_groupMaxCount
+		return lifetimeConfiguration
+	}
+
+	// MARK: - Initialization
+
+	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+		self.trackLifetime()
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+
+		self.trackLifetime()
+	}
+
+#endif
+}
+
+#if canImport(LifetimeTracker)
+
+extension SMFBaseTableViewController: LifetimeTrackable {}
+
+#endif

--- a/LifetimeTracker/SMFBaseViewController.swift
+++ b/LifetimeTracker/SMFBaseViewController.swift
@@ -1,0 +1,65 @@
+//
+//  SMFBaseViewController.swift
+//  SMF-iOS-CommonProjectSetupFiles
+//
+//  Created by Hans Seiffert on 04.12.18.
+//  Copyright © 2018 Smart Mobile Factory GmbH. All rights reserved.
+//
+
+import UIKit
+
+#if canImport(LifetimeTracker)
+
+import LifetimeTracker
+
+#endif
+
+class SMFBaseViewController: UIViewController, SMFLifetimeTrackable {
+
+	// MARK: - LifetimeTracker Configuration (without import)
+
+	class var lt_maxCount: Int {
+		return 1
+	}
+
+	class var lt_groupName: String? {
+		return String(describing: self)
+	}
+
+	class var lt_groupMaxCount: Int? {
+		return nil
+	}
+
+	// MARK: - LifetimeTracker Configuration (with import)
+
+#if canImport(LifetimeTracker)
+
+	class var lifetimeConfiguration: LifetimeConfiguration {
+		let lifetimeConfiguration = LifetimeConfiguration(maxCount: self.lt_maxCount)
+		lifetimeConfiguration.groupName = self.lt_groupName
+		lifetimeConfiguration.groupMaxCount = self.lt_groupMaxCount
+		return lifetimeConfiguration
+	}
+
+	// MARK: - Initialization
+
+	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+
+		self.trackLifetime()
+	}
+
+	required init?(coder aDecoder: NSCoder) {
+		super.init(coder: aDecoder)
+
+		self.trackLifetime()
+	}
+
+#endif
+}
+
+#if canImport(LifetimeTracker)
+
+extension SMFBaseViewController: LifetimeTrackable {}
+
+#endif

--- a/LifetimeTracker/SMFLifetimeTrackable.swift
+++ b/LifetimeTracker/SMFLifetimeTrackable.swift
@@ -1,0 +1,20 @@
+//
+//  SMFLifetimeTrackable.swift
+//  SMF-iOS-CommonProjectSetupFiles
+//
+//  Created by Hans Seiffert on 04.12.18.
+//  Copyright © 2018 Smart Mobile Factory GmbH. All rights reserved.
+//
+
+import UIKit
+
+/// Protocol which duplicates the configuration from LifetimeTracker
+/// It is used to enable projects to only add LifetimeTracker to some targets (e.g. not to the Live app) as this protocol defines everything which is needed without the need to import LifetimeTracker
+protocol SMFLifetimeTrackable {
+
+	static var lt_maxCount: Int { get }
+
+	static var lt_groupName: String? { get }
+
+	static var lt_groupMaxCount: Int? { get }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Helpers which can be added manually to the Xcode project which should be used:
 
 - [HockeySDK.swift](#hockeyapp-sdk)
 - [BuglifeSDK.swift](#buglife-sdk)
+- [LifetimeTrackerSDK](#lifetimetracker-sdk)
 
 Scripts which should be called during the build phase:
 
@@ -133,6 +134,20 @@ If you want to use a diferent `LIFEInvocationOptions` (the default is `.shake`) 
 ```
 BuglifeSDK.setup(withOption: .screenshot)
 ```
+
+### LifetimeTracker-SDK
+
+This repo contains the `LifetimeTracker-SDK` helper struct and SMF base view controllers. Together with a custom protocol - which duplicates the LifetimeTracker configuration without exposing any LifetimeTracker type - the base view controller and setup can be added to a project even if LifetimeTracker is not part of the project.
+
+Multiple `#if canImport(LifetimeTracker)` checks make sure that targets with LifetimeTracker are using it and that other targets work as well without any code changes.
+
+### Integrate it into the project
+
+- Add the folder `LifetimeTracker` to all targets
+- Call `LifetimeTrackerSDK.setup()` in the app delegate
+- Use the base view controllers as parent for all of your view controllers
+- Use the LifetimeTracker Pod in the targets you want to
+
 
 ## Scripts to be called during Build phase
 


### PR DESCRIPTION
While updating the Xcode Templates projects, I realized that we are missing a default LifetimeTracker helper. The files in this PR enables us to add LifetimeTracker only to the targets we want to (Alpha) without the need to implement the annoying logic in the projects itself.