### PR TITLE
Add new rule for empty param in case

### DIFF
--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -203,7 +203,7 @@ custom_rules:
     severity: warning
   missing_brackets:
     name: "Missing brackets"
-    regex: '(^(\t| )*(if|\} else if) (((?!(let|var|\())).)*\{)'
+    regex: '(^(\t| )*(if|\} else if) (((?!(case|let|var|\())).)*\{)'
     message: "If statements should be surrounded by rounded brackets"
     severity: warning
   empty_closure_params:

--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -152,6 +152,11 @@ custom_rules:
       - comment
       - doccomment
       - doccomment.field
+  unnecessary_empty_type:
+    name: "Unnecessary empty type"
+    regex: 'case.*\(_\):'
+    message: "Unnecessary empty type in case. Remove '(_)' from case"
+    severity: warning
   comments_capitalized_ignore_possible_code:
     name: "Capitalize First Word In Comment"
     regex: '(// +(?!swiftlint)[a-z]+)'

--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -152,9 +152,9 @@ custom_rules:
       - comment
       - doccomment
       - doccomment.field
-  unnecessary_empty_type:
-    name: "Unnecessary empty type"
-    regex: 'case.*\(_\):'
+  unnecessary_empty_type_in_case:
+    name: "Unnecessary empty type in case"
+    regex: '\(_\):'
     message: "Unnecessary empty type in case. Remove '(_)' from case"
     severity: warning
   comments_capitalized_ignore_possible_code:


### PR DESCRIPTION
`			switch enumType {
			case .case1(_):
				break
			default:
}`

We don't need the (_) this can work with case1:

if you have any suggestion on how to improve the regex to include the 'case' please help