### PR TITLE
Modify missing line rule

### DIFF
--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -267,7 +267,7 @@ custom_rules:
       - typeidentifier
   missing_empty_line:
     name: "Missing Empty Line"
-    regex: '(?-smxi)(\}\n)([ \t]*?)([^\n\}\t ])'
+    regex: '(?-smxi)(\}\n)([ \t]*?)([^\n|\.\}\t ])'
     message: "Missing empty line."
     severity: warning
   get_prefixed_function:


### PR DESCRIPTION
This rule was misleadingly triggered when there was a chain of single line function calls.

Wrong Catch:

```SWIFT
_ = seq.filter { $0 > 0 }
	.map { "\($0)" }
	.map { $0 + "ABC" }
```