### PR TITLE
Improve `missing_empty_line` Rule

### DIFF
--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -70,7 +70,6 @@ opt_in_rules:
   - literal_expression_end_indentation
   - lower_acl_than_parent
   - modifier_order
-  - multiline_arguments
   - multiline_function_chains
   - multiline_literal_brackets
   - convenience_type
@@ -267,7 +266,7 @@ custom_rules:
       - typeidentifier
   missing_empty_line:
     name: "Missing Empty Line"
-    regex: '(?-smxi)(\}\n)([ \t]*?)([^\n|\.\}\t ])'
+    regex: '(?-smxi)(\}\n)([ \t]*?)(\n+?[\t ]*?})'
     message: "Missing empty line."
     severity: warning
   get_prefixed_function:


### PR DESCRIPTION
# Remove Rule:
`multiline_arguments`

## Reason:
This Rule was triggered for the following example:
```
UIView.animate(withDuration: 0.3, animations: {
	print("...")
}, completion: { (success: Bool) in
	print("---")
})
```
Rule intended to format the code like:
```
UIView.animate(
	withDuration: 0.3, 
	animations: {
		print("...")
	},
	completion: { (success: Bool) in
		print("---")
	}
)
```
Might be more logical but is not (yet) intended to be.

# Modified Rule:
`missing_empty_line`

## What has been modified:
This Rule was triggered whenever a closing Bracket was not followed by one of the following characters: `\n`, `.`, `}`, `\t` or ` `. Since we opened up our rules on so-called one-liners (`let map = [1, 2].map { "\($0)" }`), this Rule needs modification.

## Modification:
This Rule is now just triggering if there are empty lines between two closing curly Brackets (`}` ).

will trigger at:
```
class ABC {

	func test() {
		print("something")
	}

}
```

but not for:

```
let map = [1, 2].map { "\($0)" }
let map2 = [1, 2].map { "\($0)" }
```