### PR TITLE
Don't start AppCenterSDK when no services should be enabled

### DIFF
--- a/AppCenter/AppCenterSDK+HiDrive.swift
+++ b/AppCenter/AppCenterSDK+HiDrive.swift
@@ -58,11 +58,21 @@ class AppCenterSDK: NSObject {
 
 		self.delegate = AppCenterSDKDelegate(isLogUploadEnabled: configuration.isLogUploadEnabled)
 
+		var services = [AnyClass]()
+
 		#if !os(macOS)
-		let services = (configuration.isDistributionEnabled == true) ? [MSCrashes.self, MSDistribute.self] : [MSCrashes.self]
-		#else
-		let services = [MSCrashes.self]
+		if (configuration.isDistributionEnabled == true) {
+			services.append(MSDistribute.self)
+		}
 		#endif
+
+		if (configuration.isCrashReportEnabled == true) {
+			services.append(MSCrashes.self)
+		}
+
+		guard (services.isEmpty == false) else {
+			return
+		}
 
 		MSAppCenter.start(configuration.appSecret, withServices: services)
 		MSCrashes.setEnabled(configuration.isCrashReportEnabled)


### PR DESCRIPTION
https://smartmobilefactory.atlassian.net/browse/STRATODRVE-4263

The AppCenterSDK was always being started with crash reporting even when crash reporting was disabled. This call to start causes the SDK to log a bunch of info about the device which shouldn't be happening until the user opts in to the data collection.