### PR TITLE
SMFI-1033: Disable certain rules for SwiftUI Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ The script for an app should look like:
 ```
 "${SRCROOT}/Submodules/SMF-iOS-CommonProjectSetupFiles/setup-common-project-files.sh" --buildconfig "${CONFIGURATION}" --targettype "${PRODUCT_TYPE}"
 ```
+
+If the App uses SwiftUI, this call should be used:
+
+```
+"${SRCROOT}/Submodules/SMF-iOS-CommonProjectSetupFiles/setup-common-project-files.sh" --buildconfig "${CONFIGURATION}" --targettype "${PRODUCT_TYPE}" --SwiftUI
+```
+
 If you're developing on a framework use this line on the all of your Unit Test targets:
 
 ```

--- a/SwiftLint/copy-and-run-swiftlint-config.sh
+++ b/SwiftLint/copy-and-run-swiftlint-config.sh
@@ -175,7 +175,7 @@ else
 	fi
 fi
 
-if [[ $isFramework == true ]]; then
+if [ $isFramework = true ]; then
 	# Merge with framework config
 	temporaryMergedSwiftLintConfigFilename="$temporarySwiftLintConfigFilename.merged"
 	cat "$temporarySwiftLintConfigFilename" "swiftlint+frameworks.yml" > "$temporaryMergedSwiftLintConfigFilename"

--- a/SwiftLint/copy-and-run-swiftlint-config.sh
+++ b/SwiftLint/copy-and-run-swiftlint-config.sh
@@ -125,7 +125,7 @@ function add_swiftUI_disabled_rules () {
 cd "$scriptBaseFolderPath"
 
 # Disabled certain rules listet in swiftlint+swiftUI.yml if this is a swiftUI project
-if [ $swiftUI = true]; then
+if [ $swiftUI = true ]; then
 	add_swiftUI_disabled_rules
 fi
 

--- a/SwiftLint/swiftlint+swiftUI.yml
+++ b/SwiftLint/swiftlint+swiftUI.yml
@@ -1,0 +1,12 @@
+###
+# swiftlint+swiftUI.yml
+# For a swiftUI projects only
+#
+# This list of disabled rules gets appended to the swiftlint.yml when it gets copied into the root project directory.
+# You can add more "disabled_rules" here.
+
+# rule identifiers to exclude from running
+disabled_rules:
+  - multiple_closures_with_trailing_closure
+  - missing_closure_name
+  - missing_closure_datatype

--- a/SwiftLint/swiftlint+swiftUI.yml
+++ b/SwiftLint/swiftlint+swiftUI.yml
@@ -9,4 +9,3 @@
 disabled_rules:
   - multiple_closures_with_trailing_closure
   - missing_closure_name
-  - missing_closure_datatype

--- a/setup-common-project-files.sh
+++ b/setup-common-project-files.sh
@@ -17,6 +17,7 @@ readonly noXcodeCheck="--no-xcodecheck"
 readonly buildConfigurationFlag="--buildconfig"
 readonly targetTypeFlag="--targettype"
 readonly breakingInternalFrameworkVersioningFlag="--use-breaking-internal-framework-versioning"
+readonly swiftUIFlag="--SwiftUI"
 
 readonly scriptBaseFolderPath="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -33,6 +34,7 @@ callCodeClimate=true
 checkXcodeVersion=true
 projectDir="$(pwd)"
 isDebugConfiguration=false
+isSwiftUIProject=false
 
 #
 # Methods
@@ -45,6 +47,7 @@ function display_usage () {
 	echo -e "$noCodebeatFlag\t\t\t\t- Don't copy the default SMF codebeat configuration"
 	echo -e "$noCodeClimateFlag\t\t\t- Don't copy the default SMF Code Climate configuration"
 	echo -e "$breakingInternalFrameworkVersioningFlag\t -Use the \"BreakingInternal framework versioning system\" (only for frameworks)"
+	echo -e "$swiftUIFlag\t\t\t\t- Use custom SwiftLint rules for swift ui projects"
 	echo -e "\nUsage:\n$ $0 $noCodebeatFlag"
 	echo -e "or:\n$ $0 $noCodebeatFlag /Code/Project/Test"
 }
@@ -93,6 +96,11 @@ while test $# -gt 0; do
 			shift
 			# break
 			;;
+		$swiftUIFlag)
+			isSwiftUIProject=true
+			shift
+			# break
+			;;
 		$noCodeClimateFlag)
 			callCodeClimate=false
 			shift
@@ -123,7 +131,7 @@ cd "$scriptBaseFolderPath"
 #
 
 if [ $callSwiftlint = true ]; then
-	./SwiftLint/copy-and-run-swiftlint-config.sh "$projectDir" $isFramework || exit 1;
+	./SwiftLint/copy-and-run-swiftlint-config.sh "$projectDir" $isFramework $isSwiftUIProject || exit 1;
 fi
 
 if [ $callCodebeat = true ]; then


### PR DESCRIPTION
If the `--SwiftUI` flag is provided, the rules in the _swiftlint+swiftUI.yml_ will not be used in the swift lint process.