### PR TITLE
added missing_docs to framework rules

### DIFF
--- a/SwiftLint/swiftlint+frameworks.yml
+++ b/SwiftLint/swiftlint+frameworks.yml
@@ -10,4 +10,4 @@
 #  - missing_docs
 
 #missing_docs:
-#  warning: open, public, internal
+#  warning: open, public #, internal TODO: enable check for internal at some point

--- a/SwiftLint/swiftlint+frameworks.yml
+++ b/SwiftLint/swiftlint+frameworks.yml
@@ -7,3 +7,7 @@
 
 #opt_in_rules:
 #  - explicit_top_level_acl
+#  - missing_docs
+
+#missing_docs:
+#  warning: open, public, internal


### PR DESCRIPTION
added `missing_docs` for framework only to be uncommented once we solved the SwiftLint configuration merge issue @kevindelord is working on