### PR TITLE
Feature/smfit 1963

### DIFF
--- a/SwiftLint/swiftlint+frameworks.yml
+++ b/SwiftLint/swiftlint+frameworks.yml
@@ -21,3 +21,8 @@ excluded:
 opt_in_rules:
   - explicit_acl
   - missing_docs
+
+missing_docs:
+  warning:
+    - open
+    - public

--- a/SwiftLint/swiftlint+frameworks.yml
+++ b/SwiftLint/swiftlint+frameworks.yml
@@ -21,8 +21,3 @@ excluded:
 opt_in_rules:
   - explicit_acl
   - missing_docs
-
-missing_docs:
-  warning:
-    - open
-    - public

--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -1,6 +1,6 @@
 ###
 # Swiftlint configuration file.
-# Latest version supported: 0.39.2
+# Latest version supported: 0.45.0
 # Any newer version hasn't been checked yet and might not follow the style guide.
 ###
 
@@ -84,7 +84,6 @@ opt_in_rules:
 
 analyzer_rules: # Rules run by `swiftlint analyze` (experimental)
   - explicit_self
-  - unused_import
 
 # rule parameters
 file_length:

--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -117,11 +117,6 @@ large_tuple:
   warning: 4
   error: 6
 
-missing_docs:
-  warning:
-    - open
-    - public
-
 type_name:
   min_length: 3
   max_length: 60

--- a/SwiftLint/swiftlint.yml
+++ b/SwiftLint/swiftlint.yml
@@ -100,7 +100,7 @@ cyclomatic_complexity:
 nesting:
   type_level:
     warning: 6
-  statement_level:
+  function_level:
     warning: 6
 
 function_body_length:


### PR DESCRIPTION
- Updated swiftlint 0.45.0
- Rename statement_level to function_level (deprecated)
- Remove missing_doc configuration: we are already using the default value
- I removed `unused_import` for now to limit the impact, we can think about adding it at a later stage.